### PR TITLE
Fix Paths for GitHub Pages Deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,15 +12,15 @@
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css" integrity="sha384-SZXxX4whJ79/gErwcOYf+zWLeJdY/qpuqC4cAa9rOGUstPomtqpuNWT9wdPEn2fk" crossorigin="anonymous">
 
-        <link href="/assets/css/colors.css" rel="stylesheet">
-        <link href="/assets/css/custom.css" rel="stylesheet">
+        <link href="./assets/css/colors.css" rel="stylesheet">
+        <link href="./assets/css/custom.css" rel="stylesheet">
 
-        <script src="/assets/js/html2canvas.min.js" defer></script>
-        <script src="/assets/js/utils.js" defer></script>
-        <script src="/assets/js/export2image.js" defer></script>
-        <script src="/assets/js/saveModal.js" defer></script>
-        <script src="/assets/js/tier-table.js" defer></script>
-        <script src="/assets/js/main.js" defer></script>
+        <script src="./assets/js/html2canvas.min.js" defer></script>
+        <script src="./assets/js/utils.js" defer></script>
+        <script src="./assets/js/export2image.js" defer></script>
+        <script src="./assets/js/saveModal.js" defer></script>
+        <script src="./assets/js/tier-table.js" defer></script>
+        <script src="./assets/js/main.js" defer></script>
     </head>
     <body>
         <nav class="navbar navbar-expand-lg navbar-light bg-light">
@@ -121,3 +121,4 @@
         </div>
     </body>
 </html>
+


### PR DESCRIPTION
#### Description

Hello! I happened upon this project while searching for an open-source Tier List making tool, and noticed you had an open issue (#7) that needed help.

This pull request addresses the issue with incorrect paths when deploying the project to GitHub Pages. Previously, the paths for assets such as CSS and JavaScript files were not correctly set, causing 404 errors when the site was accessed through GitHub Pages.

I've tested this both locally and on GitHub Pages, and it should work perfectly on both!

#### Changes Made
- Updated asset links in `index.html` to use relative paths.